### PR TITLE
Add an option to allow for only the current table view to be exported.

### DIFF
--- a/ng-table-export.src.js
+++ b/ng-table-export.src.js
@@ -85,16 +85,17 @@ angular.module('ngTableExport', [])
             /**
              *  Generate data URI from table data
              */
-            generate: function(event, filename, table) {
+            generate: function(event, filename, table, currentPageOnly) {
 
               var isNgTable = attrs.ngTable,
                 table = table || scope.$parent.tableParams,
                 settings = table ? table.settings() : {},
                 cnt = table ? table.count() : {},
-                total = table ? settings.total : {};
+                total = table ? settings.total : {},
+                currentPageOnly = currentPageOnly === undefined ? false : currentPageOnly;
 
               // is pager on?  if so, we have to disable it temporarily
-              if (isNgTable && cnt < total) {
+              if (!currentPageOnly && isNgTable && cnt < total) {
                 var $off = settings.$scope.$on('ngTableAfterReloadData', function () {
                   // de-register callback so it won't continue firing
                   $off();


### PR DESCRIPTION
If the ng-table allows for filtering and sorting, sometimes you just want to export the page you are viewing. With this branch, you can then create two buttons like:

`Export to CSV:
<button ng-click="csv.generate($event, 'items.csv')" class="btn btn-default">Full</button>
<button ng-click="csv.generate($event, 'items.csv', $parent.tableParams, true)" class="btn btn-default">Current View</button>`